### PR TITLE
Added install and script sections to the Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ language: ruby
 rvm:
   - 1.9.3
 before_install: gem install bundler -v 1.13.6
+install: bundle install && bundle exec rake install
+script: bundle exec rake spec


### PR DESCRIPTION
This PR adds `install` and `script` steps to the Travis configuration file so the specs are run and build status reported back to GitHub on pull requests. With this, it's possible to add a build status badge to the project's readme file as such:

[![Build Status](https://travis-ci.org/asbjornu/movable_type_format.svg?branch=feature/travis-spec)](https://travis-ci.org/asbjornu/movable_type_format)