### PR TITLE
Fixed PM rollover bug with test

### DIFF
--- a/lib/movable_type_format/field.rb
+++ b/lib/movable_type_format/field.rb
@@ -113,10 +113,11 @@ module MovableTypeFormat
       return unless string
       string =~ DATE_REGEXP
       m, d, y, h, min, s, am_pm = $~.captures
-      if am_pm == " PM"
-        h = h.to_i + 12
+      m, d, y, h, min, s = [m, d, y, h, min, s].map(&:to_i)
+      if am_pm == " PM" and h < 12
+        h = h + 12
       end
-      Time.new(y.to_i, m.to_i, d.to_i, h.to_i, min.to_i, s.to_i)
+      Time.new(y, m, d, h, min, s)
     end
 
     def parse_tags(string)

--- a/spec/movable_type_format/parser_spec.rb
+++ b/spec/movable_type_format/parser_spec.rb
@@ -64,6 +64,28 @@ module MovableTypeFormat
           first.date.should == Time.new(2002, 1, 31, 15, 31, 05)
           second.date.should == Time.new(2002, 1, 31, 03, 31, 05)
       end
+      it "parses pm date correctly" do
+          mt = <<-MT
+          TITLE: One
+          DATE: 10/27/2004 12:35:59 PM
+          -----
+          BODY:
+          Body
+          -----
+
+          EXCERPT:
+          Excerpt
+          -----
+
+          --------
+          MT
+          mt.gsub!(/^\s+/, "")
+
+          entries = MovableTypeFormat.parse(mt).to_a
+          entries.count.should == 1
+          one = entries[0]
+          one.date.should == Time.new(2004, 10, 27, 12, 35, 59)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes the bug mentioned in https://github.com/labocho/movable_type_format/issues/2#issuecomment-286904630 where the time `12:35:59 PM` is having its hours incremented by 12, ending up with the invalid time `24:35:59 PM`. I also added a test for this particular case.